### PR TITLE
added missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Please see [documentation](https://fengliang.io/stannum/).
 Code sample of `Tube`:
 
 ```python
+from stannum import Tube
 import taichi as ti
 import torch
 


### PR DESCRIPTION
The code demo in the README invokes the `Tube` class but doesn't show where it came from. Haven't tried it, but pretty sure that demo code would throw a RuntimeError. If `Tube` actually doesn't need to be imported to be used (i.e. the demonstration is correct), it might be worth commenting how that works.